### PR TITLE
added .worcs file to template

### DIFF
--- a/R/worcs_template.R
+++ b/R/worcs_template.R
@@ -70,6 +70,12 @@ worcs_template <- function(path, ...) {
     }
   }
   # End license
+  
+  # create .worcs file ----------
+  write(c(paste0("Specification: 1.0"),
+          paste0("Created By: worcs ",installed.packages()[installed.packages()[,"Package"]=="worcs","Version"])),
+        file = file.path(path, ".worcs"), append = TRUE)
+  
 
 # Use renv ----------------------------------------------------------------
   norm_path <- normalizePath(path)

--- a/R/worcs_template.R
+++ b/R/worcs_template.R
@@ -73,7 +73,7 @@ worcs_template <- function(path, ...) {
   
   # create .worcs file ----------
   write(c(paste0("Specification: 1.0"),
-          paste0("Created By: worcs ",installed.packages()[installed.packages()[,"Package"]=="worcs","Version"])),
+          paste0("Created By: worcs ",packageVersion("worcs"))),
         file = file.path(path, ".worcs"), append = TRUE)
   
 


### PR DESCRIPTION
This is how I envision a minimal .worcs file. This has information on which worcs specification the directory adheres to. Let's just call the current one 1.0. In future, the specification may likely change and it will incredibly useful to obtain this information in a standardized way.
We should also store, which package and version of the package created the repository. This may be useful to post-process or correct bugs that a given package or version of package may be notorious for.