### PR TITLE
reduce dependencies of installation

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -59,9 +59,9 @@ Before installing the package, please read [this vignette](https://cjvanlissa.gi
 After reading [the vignette](https://cjvanlissa.github.io/worcs/articles/setup.html), you can install the development version of the `worcs` package from GitHub with:
 
 ``` r
-install.packages("devtools")
-devtools::install_github("crsh/papaja", dependencies = TRUE)
-devtools::install_github("cjvanlissa/worcs", dependencies = TRUE)
+if(!requireNamespace("remotes"))install.packages("remotes")
+remotes::install_github("crsh/papaja", dependencies = TRUE, update = "never")
+remotes::install_github("cjvanlissa/worcs", dependencies = TRUE, update = "never")
 tinytex::install_tinytex()
 worcs::git_credentials("your_name", "your_email")
 ```


### PR DESCRIPTION
* devtools is *much* heavier then remotes
* the vignette recommends no update (If you are prompted to update packages, just press 3: None. Updating packages this way in an interactive session sometimes leads to errors, if the packages are loaded.)