### PR TITLE
check Rmd instead of md because of spurios linebreaks

### DIFF
--- a/tests/testthat/test-codebook.R
+++ b/tests/testthat/test-codebook.R
@@ -10,8 +10,7 @@ test_that("codebook works for iris", {
   expect_true(file.exists("codebook.Rmd"))
   expect_true(file.exists("codebook.md"))
   expect_true(file.exists("codebook.csv"))
-  contents <- readLines("codebook.md")
-
+  contents <- readLines("codebook.Rmd")
   expect_true(any(contents == "The data contains 150 cases and 5 variables."))
 
   setwd(old_wd)
@@ -34,7 +33,7 @@ test_that("codebook works for PlantGrowth with missings", {
   expect_true(file.exists("codebook.Rmd"))
   expect_true(file.exists("codebook.md"))
 
-  contents <- readLines("codebook.md")
+  contents <- readLines("codebook.Rmd")
 
   expect_true(any(contents == "The data contains 84 cases and 5 variables.")) #"The data contains 30 cases and 2 variables."))
 


### PR DESCRIPTION
on linux (so travis and my system) the codebook tests fail because render introduces weird linebreaksin the md version of codebook