### PR TITLE
Delete the example that changes user's git username and email

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -16,8 +16,6 @@ has_git <- function(){
 #' @param name Character. The user name you want to use with 'Git'.
 #' @param email Character. The email address you want to use with 'Git'.
 #' @return No return value. This function is called for its side effects.
-#' @examples
-#' git_user("myname", "my@email.com")
 #' @rdname git_user
 #' @export
 #' @importFrom gert git_config_global_set

--- a/man/git_user.Rd
+++ b/man/git_user.Rd
@@ -21,6 +21,3 @@ once: \code{name = "user.name"} is set to the value of the \code{name}
 argument, and \code{name = "user.email"} is set to the value of the
 \code{email} argument.
 }
-\examples{
-git_user("myname", "my@email.com")
-}


### PR DESCRIPTION
This violates the CRAN policy: https://cran.r-project.org/web/packages/policies.html Because it modifies user's git settings.

I spent about an hour on trying to figure out how my git username and email address were changed after I ran the reverse dependency checks for the **rmarkdown** package, and finally tracked it to **worcs**. 

This example has actually bitten yourself (it's why @foobar123asdf became the author of some commits---the email address of this user happened to be `my@email.com`):

![image](https://user-images.githubusercontent.com/163582/83319107-fd348a00-a200-11ea-8a13-19384302494b.png)

![image](https://user-images.githubusercontent.com/163582/83319187-c90d9900-a201-11ea-948a-6d2508b52153.png)

It will be great if you could remove this example. Thank you!