### PR TITLE
add a docker based setup vignette

### DIFF
--- a/paper/Manuscript_DS.Rmd
+++ b/paper/Manuscript_DS.Rmd
@@ -406,7 +406,9 @@ you have to install the required software.
 This 30 minute procedure is documented
 in [the setup vignette](https://cjvanlissa.github.io/worcs/articles/setup.html).
 After setting up your system, you can use `worcs` for all of your
-projects. The `R` implementation of the workflow introduced earlier is detailed,
+projects. If you have Docker installed and you know how to use it, you may alternatively
+read [the stetup with Docker vignette](https://cjvanlissa.github.io/worcs/articles/docker.html).
+The `R` implementation of the workflow introduced earlier is detailed,
 step-by-step, in
 [the workflow vignette](https://cjvanlissa.github.io/worcs/articles/workflow.html).
 

--- a/paper/Manuscript_DS.Rmd
+++ b/paper/Manuscript_DS.Rmd
@@ -294,8 +294,9 @@ need to be installed again. This prevents long installation
 times, large space requirements, and frustration having to re-install software
 that is already installed on the system. When someone else loads your 
 project, `renv` will install all of the required packages onto a cache on their
-computer. 
-This is not a foolproof method to ensure strict computational reproducibility, but it is more user-friendly
+computer. As opposed to the alternatives `renv` is tightly integrated with the
+native R package management system and thus does not require the users to change their workflow of installing/removing and using packages.
+This is not a fail-safe method to ensure strict computational reproducibility, but it is more user-friendly
 and lightweight than any alternative out there, requiring no technical skill to
 setup. When choosing an appropriate solution for dependency management, it is
 important to consider that all solutions have a limited shelf life

--- a/paper/reviews_ds.Rmd
+++ b/paper/reviews_ds.Rmd
@@ -131,8 +131,7 @@ Response: Provide reference, clarify explanation in text.
 
 \RC{Docker is deemed as complicated for novice users, but the setup vignete looks quite complex to me as well. Wouldn't a Docker container with worcs installed be easier to use? Maybe these aspects would be better highlighted in a user evaluation.}
 
-Response: I've never used Docker. Andreas and Aaron - do you think you could clarify why worcs might have benefits over Docker? Should we make this proposed docker container available IN ADDITION to worcs as package?
-
+Response: Thank you for this thoughtful suggestion. We explained better why `renv` is more user friendly (because it builds upon the "normal" package workflow of R users). For users familiar with Docker, we have published an image on Docker Hub with all requirements of worcs installed and a Docker specific setup vignette, that is much shorter and given that you know how to use Docker easier.
 \Assignment{AP, AB}
 \WorkInProgress
 \Medium

--- a/vignettes/setup-docker.Rmd
+++ b/vignettes/setup-docker.Rmd
@@ -1,0 +1,54 @@
+---
+title: "Setting up your computer for WORCS - Docker-edition"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{docker}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+If you do not want to install R, RStudio, Latex and Git (as described in [`vignette("setup", package = "worcs")`](https://cjvanlissa.github.io/worcs/articles/setup.html)), but like to use Docker instead, follow these steps in order:
+
+1. Install [Docker](https://docs.docker.com/get-docker/)
+2. Open a terminal/cmd/shell.
+2. Start the worcs image:
+
+```{bash, eval=FALSE}
+docker run -e PASSWORD=secret -p 8787:8787 -it aaronpeikert/worcs:latest
+```
+
+3. Open [127.0.0.1:8787/](http://127.0.0.1:8787/) in a browser. Login using username=rstudio and password=secret.
+
+Then setup the container.
+
+```{r, eval=FALSE}
+renv::consent(provided = TRUE)
+worcs::git_user("your_name", "your_email")
+```
+
+To kill the container press Ctrl + C in the terminal. To save files from a Docker session on you disk you have to link a directory explicitly when starting the container:
+
+```{bash, eval=FALSE}
+-v /path/on/your/pc:/home/rstudio
+```
+
+Or in case you use Windows:
+
+```{bash, eval=FALSE}
+-v //c/path/on/your/windows/pc:/home/rstudio
+```
+
+Resulting in such command:
+
+```{bash, eval=FALSE}
+docker run -e PASSWORD=secret -p 8787:8787 -v /path/on/your/pc:/home/rstudio -it aaronpeikert/worcs:latest
+```
+
+That's it!

--- a/vignettes/setup.Rmd
+++ b/vignettes/setup.Rmd
@@ -17,6 +17,7 @@ knitr::opts_chunk$set(
 Before you can use the WORCS workflow and the full functionality of the `worcs` package, you have to install several software packages, and register on GitHub. This vignette does not assume a prior installation of `R`, so it is suitable for novice users.
 You only have to perform these steps once for every computer you intend to use `R` and `worcs` on, and the entire process should take approximately 30 minutes if you start from scratch.
 In case some software is already installed on your system, you can skip related steps. 
+In case you have Docker and you know how to use it, you may want to take a look at [`vignette("setup", package = "worcs")`](https://cjvanlissa.github.io/worcs/articles/docker.html).
 
 Follow these steps in order:
 


### PR DESCRIPTION
As one of the reviewers suggested it might be easier for some to have a prebuild docker image instead of installing R + RStudio + latex + Git.
However, @cjvanlissa et al should judge if this is actually an alternative we want to provide. No hard feeling if you delete this!
In case we want to take this on: @cjvanlissa should fork https://github.com/aaronpeikert/worcs-docker and create a Docker Hub build from it so the image is no longer aaronpeikert/worcs.