### PR TITLE
Update vignette index entries to match titles

### DIFF
--- a/vignettes/citation.Rmd
+++ b/vignettes/citation.Rmd
@@ -2,7 +2,7 @@
 title: "Citing references in worcs"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{citing}
+  %\VignetteIndexEntry{Citing references in worcs}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/git_cloud.Rmd
+++ b/vignettes/git_cloud.Rmd
@@ -2,7 +2,7 @@
 title: "Connecting to 'Git' remote repositories"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{git_cloud}
+  %\VignetteIndexEntry{Connecting to 'Git' remote repositories}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/reproduce.Rmd
+++ b/vignettes/reproduce.Rmd
@@ -2,7 +2,7 @@
 title: "Reproducing a WORCS project"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{reproduce-worcs-project}
+  %\VignetteIndexEntry{Reproducing a WORCS project}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/setup-docker.Rmd
+++ b/vignettes/setup-docker.Rmd
@@ -2,7 +2,7 @@
 title: "Setting up your computer for WORCS - Docker-edition"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{setup-docker}
+  %\VignetteIndexEntry{Setting up your computer for WORCS - Docker-edition}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/setup.Rmd
+++ b/vignettes/setup.Rmd
@@ -2,7 +2,7 @@
 title: "Setting up your computer for WORCS"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{setup}
+  %\VignetteIndexEntry{Setting up your computer for WORCS - Docker-edition}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/setup.Rmd
+++ b/vignettes/setup.Rmd
@@ -2,7 +2,7 @@
 title: "Setting up your computer for WORCS"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Setting up your computer for WORCS - Docker-edition}
+  %\VignetteIndexEntry{Setting up your computer for WORCS}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/workflow.Rmd
+++ b/vignettes/workflow.Rmd
@@ -2,7 +2,7 @@
 title: "The WORCS workflow, version 0.1.6"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{workflow}
+  %\VignetteIndexEntry{The WORCS workflow, version 0.1.6}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 bibliography: "vignettes.bib"


### PR DESCRIPTION
This will display nicer and more explicit titles in the listing from the CRAN landing page: https://cran.r-project.org/package=worcs

And according to Hadley Wickham, the vignette index entry should always match the title ([source](https://github.com/r-lib/pkgdown/issues/989#issuecomment-493487272))