### PR TITLE
Functionality: Allow users to specify which summary stats to use in the codebook

### DIFF
--- a/R/codebook.R
+++ b/R/codebook.R
@@ -59,7 +59,7 @@ make_codebook <-
     filename <- force(filename)
     function_success <- TRUE
     
-    if (stats == "") {
+    if (stats == "" || is.null(stats)) {
       summaries <- do.call(descriptives, list(x = data))
     }
     else {

--- a/R/codebook.R
+++ b/R/codebook.R
@@ -54,11 +54,22 @@ make_codebook <-
            filename = "codebook.Rmd",
            render_file = TRUE,
            csv_file = gsub("Rmd$", "csv", filename),
-           verbose = TRUE) {
+           verbose = TRUE,
+           stats = "") {
     filename <- force(filename)
     function_success <- TRUE
-
-    summaries <- do.call(descriptives, list(x = data))
+    
+    if (stats == "") {
+      summaries <- do.call(descriptives, list(x = data))
+    }
+    else {
+      identifiers <- list("name","type")
+      stats <- as.list(strsplit(stats,'\\s+')[[1]])
+      stats <- c(identifiers, stats)
+      summaries <- do.call(descriptives, list(x = data))
+      summaries <- summaries[,(names(summaries) %in% stats)]
+    }
+ 
     summaries <- cbind(summaries,
             category = NA,
             description = NA)


### PR DESCRIPTION
Hi there,

I've added some code to the codebook.R file that allows users to specify a string of summary statistics that they would like to appear in the codebook. I've tested that it works well and have had no issues. I do ensure that "name" and "type" are always specified, but there might be a better way to handle that.